### PR TITLE
feat: change spot price to twap

### DIFF
--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -251,11 +251,11 @@ impl LoanManager {
         let collateral_pool_client = loan_pool::Client::new(e, &token_collateral_address);
         let collateral_factor = collateral_pool_client.get_collateral_factor();
 
+        let amount_of_data_points = 12; // 12 * 5 min = 1h average
         let collateral_asset_price = reflector_contract
-            .lastprice(&collateral_asset)
+            .twap(&collateral_asset, &amount_of_data_points)
             .ok_or(LoanManagerError::NoLastPrice)?;
         let collateral_value = collateral_asset_price
-            .price
             .checked_mul(token_collateral_amount)
             .ok_or(LoanManagerError::OverOrUnderFlow)?
             .checked_mul(collateral_factor)
@@ -266,10 +266,9 @@ impl LoanManager {
         // get the price and calculate the value of the borrowed asset
         let borrowed_asset = Asset::Other(token_ticker);
         let asset_price = reflector_contract
-            .lastprice(&borrowed_asset)
+            .twap(&borrowed_asset, &amount_of_data_points)
             .ok_or(LoanManagerError::NoLastPrice)?;
         let borrowed_value = asset_price
-            .price
             .checked_mul(token_amount)
             .ok_or(LoanManagerError::OverOrUnderFlow)?;
 

--- a/contracts/reflector_mock/src/lib.rs
+++ b/contracts/reflector_mock/src/lib.rs
@@ -28,4 +28,7 @@ impl MockPriceOracleContract {
             timestamp: 1,
         })
     }
+    pub fn twap(_e: Env, _asset: Asset, _records: u32) -> Option<i128> {
+        Some(1)
+    }
 }


### PR DESCRIPTION
### Summary of Changes

Oracle price data calls in `calculate_health_factor()` were changed from `last_price()` to `twap()`. This is a safety measure, as `last_price` returns the last spot price which can be easy to manipulate. `twap()`(time-weighted average price) on the other hand is much harder to manipulate since it would not be economically feasible. I selected number of records to be 12 for now, which equals the average price over an hour (12 * 5min resolution).

### Considerations

This changed the return type from `Option<PriceData>` to `Option<i128>`. A new mock function was done for tests and rust-analyzer to work. This change still doesn't take in to account the possibility of oracle data going stale. This should be addressed in the future and it has been added to backlog.

### Related Issue

#123 

### Author checklist

2. Does your pull request change contract endpoint?

- [ ] Yes, changes in `loan_manager`
  - [ ] Test was added in `loan_manager.rs`
- [ ] Yes, changes in `loan_pool`
  - [ ] Test was added in `loan_pool.rs`
- [x] No

3. Does your pull request demand a new deployment of contracts

- [ ] Yes
- [x] No
