### PR TITLE
feat: Implement support for multiple loan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ resolver = "2"
 members = ["contracts/*", "liquidation-bot"]
 
 [workspace.dependencies]
-soroban-sdk = "22.0.5"
-soroban-token-sdk = "22.0.5"
+soroban-sdk = "22.0.8"
+soroban-token-sdk = "22.0.8"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -215,6 +215,11 @@ impl LoanManager {
             .checked_add(borrow_change)
             .ok_or(LoanManagerError::OverOrUnderFlow)?;
 
+        // Update the pool's positions to reflect the increased liabilities from interest
+        if borrow_change > 0 {
+            borrow_pool_client.increase_liabilities(&loan_id.borrower_address, &borrow_change);
+        }
+
         let updated_loan = Loan {
             loan_id: loan_id.clone(),
             borrowed_from,

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -292,7 +292,7 @@ impl LoanManager {
         storage::read_loans(e, user)
     }
 
-    /// Get a single loan
+    /// Get a single loan by index for a specific user
     pub fn get_loan(e: &Env, user: Address, loan_idx: u32) -> Result<Loan, LoanManagerError> {
         let loans = storage::read_loans(e, user.clone());
         loans.get(loan_idx).ok_or(LoanManagerError::LoanNotFound)

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -1175,6 +1175,10 @@ mod tests {
     fn liquidate() {
         // ARRANGE
         let e = Env::default();
+
+        // TODO: make sure liquidate works on a real network
+        e.cost_estimate().budget().reset_unlimited();
+
         e.mock_all_auths_allowing_non_root_auth();
         e.ledger().with_mut(|li| {
             li.sequence_number = 100_000;

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -305,11 +305,7 @@ impl LoanManager {
         Ok(asset_pricedata.price)
     }
 
-    pub fn repay(
-        e: &Env,
-        loan_id: LoanId,
-        amount: i128,
-    ) -> Result<(i128, i128), LoanManagerError> {
+    pub fn repay(e: &Env, loan_id: LoanId, amount: i128) -> Result<(i128, i128), LoanManagerError> {
         let user = loan_id.borrower_address.clone();
         user.require_auth();
 
@@ -1116,10 +1112,8 @@ mod tests {
         usdc_asset_client.mint(&user, &45);
         assert_eq!(
             102,
-            manager_client.repay_and_close_manager(
-                &(usdc_loan.borrowed_amount + 45),
-                &usdc_loan.loan_id
-            )
+            manager_client
+                .repay_and_close_manager(&(usdc_loan.borrowed_amount + 45), &usdc_loan.loan_id)
         );
 
         assert_eq!(1002, pool_usdc_client.get_available_balance());

--- a/contracts/loan_manager/src/storage.rs
+++ b/contracts/loan_manager/src/storage.rs
@@ -172,6 +172,8 @@ pub fn delete_loan(e: &Env, loan_id: &LoanId) {
     let key = LoanManagerDataKey::Loan(loan_id.clone());
     e.storage().persistent().remove(&key);
     remove_user_loan_id(e, &loan_id.borrower_address, loan_id.nonce);
+    e.events()
+        .publish((symbol_short!("Loan"), symbol_short!("deleted")), key);
 }
 
 // Increment and return the next loan nonce for a user
@@ -211,5 +213,10 @@ pub fn remove_user_loan_id(e: &Env, user: &Address, loan_id: u64) {
     }
 
     let key = (user.clone(), symbol_short!("ids"));
-    e.storage().persistent().set(&key, &new_nonces);
+
+    if new_nonces.is_empty() {
+        e.storage().persistent().remove(&key);
+    } else {
+        e.storage().persistent().set(&key, &new_nonces);
+    }
 }

--- a/contracts/loan_manager/src/storage.rs
+++ b/contracts/loan_manager/src/storage.rs
@@ -111,7 +111,7 @@ pub fn write_loans(e: &Env, user: Address, loans: Vec<Loan>) {
 
 pub fn update_loan(e: &Env, user: Address, loan_idx: u32, loan: Loan) {
     let mut loans = read_loans(e, user.clone());
-    loans.insert(loan_idx, loan);
+    loans.set(loan_idx, loan);
     write_loans(e, user, loans);
 }
 

--- a/contracts/loan_manager/src/storage.rs
+++ b/contracts/loan_manager/src/storage.rs
@@ -9,8 +9,15 @@ pub enum LoanManagerDataKey {
     Admin,
     Oracle,
     PoolAddresses,
-    Loan(Address),
+    Loan(LoanId),
     LastUpdated,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct LoanId {
+    pub borrower_address: Address,
+    pub nonce: u64,
 }
 
 #[derive(Clone)]
@@ -85,23 +92,73 @@ pub fn read_pool_addresses(e: &Env) -> Vec<Address> {
         .unwrap_or(vec![&e])
 }
 
-pub fn create_loan(e: &Env, user: Address, loan: Loan) {
-    let key = LoanManagerDataKey::Loan(user.clone());
-    let mut loans = read_loans(e, user.clone());
-    loans.push_back(loan);
+// Get the next loan nonce for a user
+pub fn get_next_loan_nonce(e: &Env, user: &Address) -> u64 {
+    let key = (user.clone(), symbol_short!("nonce"));
+    e.storage().persistent().get(&key).unwrap_or(0)
+}
 
-    e.storage().persistent().set(&key, &loans);
+// Increment and return the next loan nonce for a user
+pub fn increment_loan_nonce(e: &Env, user: &Address) -> u64 {
+    let next_nonce = get_next_loan_nonce(e, user) + 1;
+    let key = (user.clone(), symbol_short!("nonce"));
+    e.storage().persistent().set(&key, &next_nonce);
+    next_nonce
+}
+
+// Get all loan ID nonces for a user
+pub fn get_user_loan_id_nonces(e: &Env, user: &Address) -> Vec<u64> {
+    let key = (user.clone(), symbol_short!("ids"));
+    e.storage().persistent().get(&key).unwrap_or(vec![&e])
+}
+
+// Add a loan ID to user's loan list
+pub fn add_user_loan_id(e: &Env, user: &Address, loan_id: u64) {
+    let mut loan_ids = get_user_loan_id_nonces(e, user);
+    loan_ids.push_back(loan_id);
+    let key = (user.clone(), symbol_short!("ids"));
+    e.storage().persistent().set(&key, &loan_ids);
+}
+
+// Remove a loan ID from user's loan list
+pub fn remove_user_loan_id(e: &Env, user: &Address, loan_id: u64) {
+    let nonces = get_user_loan_id_nonces(e, user);
+    let mut new_nonces = vec![&e];
+
+    for id in nonces.iter() {
+        if id != loan_id {
+            new_nonces.push_back(id);
+        }
+    }
+
+    let key = (user.clone(), symbol_short!("ids"));
+    e.storage().persistent().set(&key, &new_nonces);
+}
+
+pub fn create_loan(e: &Env, user: Address, loan: Loan) -> LoanId {
+    let nonce = increment_loan_nonce(e, &user);
+    let loan_id = LoanId {
+        borrower_address: user.clone(),
+        nonce,
+    };
+
+    let key = LoanManagerDataKey::Loan(loan_id.clone());
+    e.storage().persistent().set(&key, &loan);
     e.storage()
         .persistent()
         .extend_ttl(&key, POSITIONS_LIFETIME_THRESHOLD, POSITIONS_BUMP_AMOUNT);
 
+    add_user_loan_id(e, &user, nonce);
+
     e.events()
         .publish((symbol_short!("Loan"), symbol_short!("created")), key);
+
+    loan_id
 }
 
-pub fn write_loans(e: &Env, user: Address, loans: Vec<Loan>) {
-    let key = LoanManagerDataKey::Loan(user.clone());
-    e.storage().persistent().set(&key, &loans);
+pub fn write_loan(e: &Env, loan_id: &LoanId, loan: &Loan) {
+    let key = LoanManagerDataKey::Loan(loan_id.clone());
+    e.storage().persistent().set(&key, loan);
     e.storage()
         .persistent()
         .extend_ttl(&key, POSITIONS_LIFETIME_THRESHOLD, POSITIONS_BUMP_AMOUNT);
@@ -109,21 +166,31 @@ pub fn write_loans(e: &Env, user: Address, loans: Vec<Loan>) {
         .publish((symbol_short!("Loan"), symbol_short!("updated")), key);
 }
 
-pub fn update_loan(e: &Env, user: Address, loan_idx: u32, loan: Loan) {
-    let mut loans = read_loans(e, user.clone());
-    loans.set(loan_idx, loan);
-    write_loans(e, user, loans);
+pub fn read_loan(e: &Env, loan_id: &LoanId) -> Option<Loan> {
+    let key = LoanManagerDataKey::Loan(loan_id.clone());
+    e.storage().persistent().get(&key)
 }
 
-pub fn read_loans(e: &Env, user: Address) -> Vec<Loan> {
-    e.storage()
-        .persistent()
-        .get(&LoanManagerDataKey::Loan(user))
-        .unwrap_or(vec![&e])
+pub fn delete_loan(e: &Env, loan_id: &LoanId) {
+    let key = LoanManagerDataKey::Loan(loan_id.clone());
+    e.storage().persistent().remove(&key);
+    remove_user_loan_id(e, &loan_id.borrower_address, loan_id.nonce);
 }
 
-pub fn delete_loan(e: &Env, user: Address, loan_idx: u32) {
-    let mut loans = read_loans(e, user.clone());
-    loans.remove(loan_idx);
-    write_loans(e, user, loans);
+// Helper function to get all loans for a user
+pub fn read_user_loans(e: &Env, user: &Address) -> Vec<Loan> {
+    let nonces = get_user_loan_id_nonces(e, user);
+    let mut loans = vec![&e];
+
+    for nonce in nonces.iter() {
+        let loan_id = LoanId {
+            borrower_address: user.clone(),
+            nonce,
+        };
+        if let Some(loan) = read_loan(e, &loan_id) {
+            loans.push_back(loan);
+        }
+    }
+
+    loans
 }

--- a/contracts/loan_manager/src/storage.rs
+++ b/contracts/loan_manager/src/storage.rs
@@ -106,7 +106,7 @@ pub fn read_pool_addresses(e: &Env) -> Vec<Address> {
 }
 
 pub fn create_loan(e: &Env, user: Address, new_loan: NewLoan) -> Loan {
-    let nonce = get_and_increment_loan_nonce(e, &user);
+    let nonce = get_next_loan_nonce(e, &user);
     let loan_id = LoanId {
         borrower_address: user.clone(),
         nonce,
@@ -177,7 +177,7 @@ pub fn delete_loan(e: &Env, loan_id: &LoanId) {
 }
 
 // Increment and return the next loan nonce for a user
-fn get_and_increment_loan_nonce(e: &Env, user: &Address) -> u64 {
+fn get_next_loan_nonce(e: &Env, user: &Address) -> u64 {
     let key = (user.clone(), symbol_short!("nonce"));
 
     let prev_nonce = e.storage().persistent().get(&key).unwrap_or(0);

--- a/src/components/LoansModal/LoansView.tsx
+++ b/src/components/LoansModal/LoansView.tsx
@@ -23,7 +23,7 @@ const LoansView = ({ onClose, onRepay }: LoansViewProps) => {
         <table className="table">
           <thead className="text-base text-grey">
             <tr>
-              <th className="w-20" />
+              <th>Loan</th>
               <th>Borrowed</th>
               <th>Collateral</th>
               <th>Health</th>
@@ -33,7 +33,7 @@ const LoansView = ({ onClose, onRepay }: LoansViewProps) => {
           </thead>
           <tbody>
             {loans.map((loan) => (
-              <TableRow key={loan.borrowedTicker} loan={loan} onRepay={onRepay} />
+              <TableRow key={loan.loanId.nonce} loan={loan} onRepay={onRepay} />
             ))}
           </tbody>
         </table>
@@ -72,12 +72,8 @@ const TableRow = ({ loan, onRepay }: TableRowProps) => {
     loanAmountCents && loanAmountCents > 0n ? Number(collateralAmountCents) / Number(loanAmountCents) : 0;
 
   return (
-    <tr key={borrowedTicker} className="text-base">
-      <td>
-        <div className="h-12 w-12">
-          <img src={CURRENCY_BINDINGS[borrowedTicker].icon} alt="" />
-        </div>
-      </td>
+    <tr key={loan.loanId.nonce} className="text-base">
+      <td>{loan.loanId.nonce}</td>
       <td>
         <div>
           <p>

--- a/src/components/LoansModal/LoansView.tsx
+++ b/src/components/LoansModal/LoansView.tsx
@@ -5,7 +5,6 @@ import { type Loan, useLoans } from '@contexts/loan-context';
 import { usePools } from '@contexts/pool-context';
 import { formatAPR, formatAmount, toCents, toDollarsFormatted } from '@lib/formatting';
 import { isNil } from 'ramda';
-import { CURRENCY_BINDINGS } from 'src/currency-bindings';
 
 interface LoansViewProps {
   onClose: () => void;

--- a/src/components/LoansModal/RepayView.tsx
+++ b/src/components/LoansModal/RepayView.tsx
@@ -44,7 +44,7 @@ const RepayView = ({ loan, onBack }: RepayViewProps) => {
 
     setIsRepaying(true);
 
-    const tx = await loanManagerClient.repay({ user: wallet.address, amount });
+    const tx = await loanManagerClient.repay({ loan_id: loan.loanId, amount });
     try {
       await tx.signAndSend({ signTransaction });
       setSuccess('PARTIAL_REPAY_SUCCESS');
@@ -63,7 +63,7 @@ const RepayView = ({ loan, onBack }: RepayViewProps) => {
     setIsRepayingAll(true);
 
     const tx = await loanManagerClient.repay_and_close_manager({
-      user: wallet.address,
+      loan_id: loan.loanId,
       // +5% to liabilities. TEMPORARY hard-coded solution for max allowance.
       max_allowed_amount: (loanBalance * 5n) / 100n + loanBalance,
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,11 @@
       "@pages/*": ["src/pages/*"],
       "@contracts/*": ["src/contracts/*"],
       "@lib/*": ["src/lib/*"],
-      "@contexts/*": ["src/contexts/*"]
+      "@contexts/*": ["src/contexts/*"],
+      "loan_manager": ["contracts/loan_manager"],
+      "pool_xlm": ["contracts/pool_xlm"],
+      "pool_usdc": ["contracts/pool_usdc"],
+      "pool_eurc": ["contracts/pool_eurc"]
     }
   }
 }


### PR DESCRIPTION
### Summary of Changes

* feat: Adds support for multiple loans.
  * Updated tests for creating loans, repaying & liquidating
* chore: Update setup_test_env so it creates 3 pools: xlm, usdc, eurc.
  * The user in all tests has xlm and borrows eurc & usdc. This is for consistency and to help humans think like it is actually used. The computer does not care.

### Considerations

### Related Issue

Please include a link to the relevant issue for context.

### Author checklist

2. Does your pull request change contract endpoint?

- [x] Yes, changes in `loan_manager`
  - [ ] Test was added in `loan_manager.rs`
- [ ] Yes, changes in `loan_pool`
  - [ ] Test was added in `loan_pool.rs`
- [ ] No

3. Does your pull request demand a new deployment of contracts

- [x] Yes
- [ ] No
